### PR TITLE
Update NfcPlugin.java

### DIFF
--- a/src/android/src/com/chariotsolutions/nfc/plugin/NfcPlugin.java
+++ b/src/android/src/com/chariotsolutions/nfc/plugin/NfcPlugin.java
@@ -551,7 +551,7 @@ public class NfcPlugin extends CordovaPlugin implements NfcAdapter.OnNdefPushCom
                     }
 
                     if (p2pMessage != null) {
-                        nfcAdapter.setNdefPushMessage(p2pMessage, getActivity());
+                        //nfcAdapter.setNdefPushMessage(p2pMessage, getActivity());
                     }
                 } catch (IllegalStateException e) {
                     // issue 110 - user exits app with home button while nfc is initializing
@@ -586,12 +586,12 @@ public class NfcPlugin extends CordovaPlugin implements NfcAdapter.OnNdefPushCom
 
             if (nfcAdapter == null) {
                 callbackContext.error(STATUS_NO_NFC);
-            } else if (!nfcAdapter.isNdefPushEnabled()) {
-                callbackContext.error(STATUS_NDEF_PUSH_DISABLED);
+            // } else if (!nfcAdapter.isNdefPushEnabled()) {
+            //     callbackContext.error(STATUS_NDEF_PUSH_DISABLED);
             } else {
-                nfcAdapter.setOnNdefPushCompleteCallback(NfcPlugin.this, getActivity());
+                // nfcAdapter.setOnNdefPushCompleteCallback(NfcPlugin.this, getActivity());
                 try {
-                    nfcAdapter.setBeamPushUris(uris, getActivity());
+                    // nfcAdapter.setBeamPushUris(uris, getActivity());
 
                     PluginResult result = new PluginResult(PluginResult.Status.NO_RESULT);
                     result.setKeepCallback(true);
@@ -612,11 +612,11 @@ public class NfcPlugin extends CordovaPlugin implements NfcAdapter.OnNdefPushCom
 
             if (nfcAdapter == null) {
                 callbackContext.error(STATUS_NO_NFC);
-            } else if (!nfcAdapter.isNdefPushEnabled()) {
-                callbackContext.error(STATUS_NDEF_PUSH_DISABLED);
+            // } else if (!nfcAdapter.isNdefPushEnabled()) {
+            //     callbackContext.error(STATUS_NDEF_PUSH_DISABLED);
             } else {
-                nfcAdapter.setNdefPushMessage(p2pMessage, getActivity());
-                nfcAdapter.setOnNdefPushCompleteCallback(NfcPlugin.this, getActivity());
+                // nfcAdapter.setNdefPushMessage(p2pMessage, getActivity());
+                // nfcAdapter.setOnNdefPushCompleteCallback(NfcPlugin.this, getActivity());
 
                 PluginResult result = new PluginResult(PluginResult.Status.NO_RESULT);
                 result.setKeepCallback(true);
@@ -632,7 +632,7 @@ public class NfcPlugin extends CordovaPlugin implements NfcAdapter.OnNdefPushCom
             NfcAdapter nfcAdapter = NfcAdapter.getDefaultAdapter(getActivity());
 
             if (nfcAdapter != null) {
-                nfcAdapter.setNdefPushMessage(null, getActivity());
+                // nfcAdapter.setNdefPushMessage(null, getActivity());
             }
 
         });
@@ -644,7 +644,7 @@ public class NfcPlugin extends CordovaPlugin implements NfcAdapter.OnNdefPushCom
             NfcAdapter nfcAdapter = NfcAdapter.getDefaultAdapter(getActivity());
 
             if (nfcAdapter != null) {
-                nfcAdapter.setBeamPushUris(null, getActivity());
+                // nfcAdapter.setBeamPushUris(null, getActivity());
             }
 
         });


### PR DESCRIPTION
Commented out all obsolete methods in Android API34 (Android14). These methods existed on API33 (Android 13) but are no longer available.